### PR TITLE
Fix readonly and writeonly field bug

### DIFF
--- a/codegen/typescript/typescript_processor.py
+++ b/codegen/typescript/typescript_processor.py
@@ -232,8 +232,13 @@ class TypeScriptProcessor:
         else:
             return "any"
 
-    def extract_properties_from_schema(self, schema) -> tuple[Dict[str, str], List[str]]:
-        """Extract properties and required fields from OpenAPI schema"""
+    def extract_properties_from_schema(self, schema, context: str = "both") -> tuple[Dict[str, str], List[str]]:
+        """Extract properties and required fields from OpenAPI schema
+        
+        Args:
+            schema: The OpenAPI schema to extract properties from
+            context: Either 'request', 'response', or 'both' to filter readonly/writeonly fields
+        """
         properties = {}
         required = []
         
@@ -262,16 +267,29 @@ class TypeScriptProcessor:
         required_fields = schema.get("required", [])
         
         for prop_name, prop_schema in schema["properties"].items():
+            # Filter properties based on readonly/writeonly and context
+            is_readonly = isinstance(prop_schema, dict) and prop_schema.get("readOnly", False)
+            is_writeonly = isinstance(prop_schema, dict) and prop_schema.get("writeOnly", False)
+            
+            # Skip readonly fields in request types
+            if context == "request" and is_readonly:
+                continue
+            
+            # Skip writeonly fields in response types  
+            if context == "response" and is_writeonly:
+                continue
+            
             prop_type = self.extract_schema_type(prop_schema)
             properties[prop_name] = prop_type
             if prop_name in required_fields:
+                # Only add to required if the field is actually included
                 required.append(prop_name)
         
         return properties, required
 
-    def create_type_definition(self, name: str, schema, description: str = None, custom_type: Optional[str] = None) -> TypeScriptTypeDefinition:
+    def create_type_definition(self, name: str, schema, description: str = None, custom_type: Optional[str] = None, context: str = "both") -> TypeScriptTypeDefinition:
         """Create a TypeScript type definition from OpenAPI schema"""
-        properties, required = self.extract_properties_from_schema(schema)
+        properties, required = self.extract_properties_from_schema(schema, context)
         
         # Check if we already have a type with the same properties
         existing_type = self._is_duplicate_type(properties, required)
@@ -310,7 +328,8 @@ class TypeScriptProcessor:
         return self.create_type_definition(
             type_name,
             json_content.schema,
-            f"Request data for {router.method} {router.path}"
+            f"Request data for {router.method} {router.path}",
+            context="request"
         )
 
     def extract_response_type(self, router: Router, controller_name: str, action_name: Optional[str] = None) -> Optional[TypeScriptTypeDefinition]:
@@ -353,7 +372,8 @@ class TypeScriptProcessor:
                 type_name,
                 {"type": "array", "items": {"type": "any"}},  # Simplified schema for array type
                 f"Response data for {router.method} {router.path}",
-                custom_type=array_type  # Use the actual array type
+                custom_type=array_type,  # Use the actual array type
+                context="response"
             )
         
         # Handle regular object responses
@@ -366,7 +386,8 @@ class TypeScriptProcessor:
         return self.create_type_definition(
             type_name,
             json_content.schema,
-            f"Response data for {router.method} {router.path}"
+            f"Response data for {router.method} {router.path}",
+            context="response"
         )
 
     def extract_params_type(self, router: Router, controller_name: str, action_name: Optional[str] = None) -> Optional[TypeScriptTypeDefinition]:
@@ -405,7 +426,8 @@ class TypeScriptProcessor:
         return self.create_type_definition(
             type_name,
             params_schema,
-            f"Query parameters for {router.method} {router.path}"
+            f"Query parameters for {router.method} {router.path}",
+            context="request"
         )
 
     def process(self) -> TypeScriptAst:
@@ -579,7 +601,8 @@ class TypeScriptProcessor:
             self.create_type_definition(
                 type_name,
                 schema_data,
-                f"Schema definition for {schema_name}"
+                f"Schema definition for {schema_name}",
+                context="both"
             )
         
         # Extract enum types from object properties

--- a/codegen/typescript/typescript_processor.py
+++ b/codegen/typescript/typescript_processor.py
@@ -96,7 +96,8 @@ class TypeScriptProcessor:
             return self.create_type_definition(
                 type_name,
                 action.response_schema,
-                f"Response data for action {action.name} in {controller_name}"
+                f"Response data for action {action.name} in {controller_name}",
+                context="response"
             )
         return None
 

--- a/output/modules/auth.ts
+++ b/output/modules/auth.ts
@@ -1,0 +1,65 @@
+import * as AuthType from "../types/auth";
+import { AxiosResponse } from "axios";
+import { Connection } from "../client/connection";
+import { BaseController } from "../utils/baseController";
+import { RequestConfig } from "../utils/globalTypes";
+
+export class AuthLogin extends BaseController {
+    constructor(conn: Connection, token?: string) {
+        super(conn, token);
+    }
+    /** POST /auth/login/ */
+    async auth_login_create(data: AuthType.AuthLoginRequestData, config?: RequestConfig
+    ): Promise<AxiosResponse<AuthType.AuthLoginResponseData>> {
+        return await this.axiosPost(`/auth/login/`, data, config);
+    }
+}
+
+export class AuthLogout extends BaseController {
+    constructor(conn: Connection, token?: string) {
+        super(conn, token);
+    }
+    /** POST /auth/logout/ */
+    async auth_logout_create(config?: RequestConfig
+    ): Promise<AxiosResponse<any>> {
+        return await this.axiosPost(`/auth/logout/`, config);
+    }
+}
+
+export class AuthLogoutall extends BaseController {
+    constructor(conn: Connection, token?: string) {
+        super(conn, token);
+    }
+    /** POST /auth/logoutall/ */
+    async auth_logoutall_create(config?: RequestConfig
+    ): Promise<AxiosResponse<any>> {
+        return await this.axiosPost(`/auth/logoutall/`, config);
+    }
+}
+
+export class AuthRegister extends BaseController {
+    constructor(conn: Connection, token?: string) {
+        super(conn, token);
+    }
+    /** POST /auth/register/ */
+    async auth_register_create(data: AuthType.AuthRegisterRequestData, config?: RequestConfig
+    ): Promise<AxiosResponse<AuthType.AuthRegisterResponseData>> {
+        return await this.axiosPost(`/auth/register/`, data, config);
+    }
+}
+
+export class AuthController extends BaseController {
+    public readonly login: AuthLogin;
+    public readonly logout: AuthLogout;
+    public readonly logoutall: AuthLogoutall;
+    public readonly register: AuthRegister;
+
+    constructor(connection: Connection, token?: string) {
+        super(connection, token);
+        this.login = new AuthLogin(this.conn);
+        this.logout = new AuthLogout(this.conn);
+        this.logoutall = new AuthLogoutall(this.conn);
+        this.register = new AuthRegister(this.conn);
+    }
+    
+}

--- a/output/modules/ayahs.ts
+++ b/output/modules/ayahs.ts
@@ -1,0 +1,49 @@
+import * as AyahsType from "../types/ayahs";
+import { AxiosResponse } from "axios";
+import { Connection } from "../client/connection";
+import { BaseController } from "../utils/baseController";
+import { RequestConfig } from "../utils/globalTypes";
+
+export class AyahsController extends BaseController {
+
+    constructor(connection: Connection, token?: string) {
+        super(connection, token);
+    }
+    
+    /** GET /ayahs/ */
+    async list(config?: RequestConfig<AyahsType.AyahsListRequestParams>
+    ): Promise<AxiosResponse<AyahsType.AyahsListResponseData>> {
+        return await this.axiosGet(`/ayahs/`, config);
+    }
+    
+    /** POST /ayahs/ */
+    async create(data: AyahsType.AyahsCreateRequestData,config?: RequestConfig
+    ): Promise<AxiosResponse<AyahsType.AyahsCreateResponseData>> {
+        return await this.axiosPost(`/ayahs/`, data, config);
+    }
+    
+    /** GET /ayahs/{uuid}/ */
+    async retrieve(uuid: string,config?: RequestConfig
+    ): Promise<AxiosResponse<AyahsType.AyahsRetrieveResponseData>> {
+        return await this.axiosGet(`/ayahs/${uuid}/`, config);
+    }
+    
+    /** PUT /ayahs/{uuid}/ */
+    async update(uuid: string,data: AyahsType.AyahsUpdateRequestData,config?: RequestConfig
+    ): Promise<AxiosResponse<AyahsType.AyahsUpdateResponseData>> {
+        return await this.axiosPut(`/ayahs/${uuid}/`, data, config);
+    }
+    
+    /** PATCH /ayahs/{uuid}/ */
+    async partialUpdate(uuid: string,data: AyahsType.AyahsPartialupdateRequestData,config?: RequestConfig
+    ): Promise<AxiosResponse<AyahsType.AyahsPartialupdateResponseData>> {
+        return await this.axiosPatch(`/ayahs/${uuid}/`, data, config);
+    }
+    
+    /** DELETE /ayahs/{uuid}/ */
+    async delete(uuid: string,config?: RequestConfig
+    ): Promise<AxiosResponse<any>> {
+        return await this.axiosDelete(`/ayahs/${uuid}/`, config);
+    }
+    
+}

--- a/output/modules/groups.ts
+++ b/output/modules/groups.ts
@@ -1,0 +1,49 @@
+import * as GroupsType from "../types/groups";
+import { AxiosResponse } from "axios";
+import { Connection } from "../client/connection";
+import { BaseController } from "../utils/baseController";
+import { RequestConfig } from "../utils/globalTypes";
+
+export class GroupsController extends BaseController {
+
+    constructor(connection: Connection, token?: string) {
+        super(connection, token);
+    }
+    
+    /** GET /groups/ */
+    async list(config?: RequestConfig
+    ): Promise<AxiosResponse<GroupsType.GroupsListResponseData>> {
+        return await this.axiosGet(`/groups/`, config);
+    }
+    
+    /** POST /groups/ */
+    async create(data: GroupsType.GroupsCreateRequestData,config?: RequestConfig
+    ): Promise<AxiosResponse<GroupsType.GroupsCreateResponseData>> {
+        return await this.axiosPost(`/groups/`, data, config);
+    }
+    
+    /** GET /groups/{id}/ */
+    async retrieve(id: string,config?: RequestConfig
+    ): Promise<AxiosResponse<GroupsType.GroupsRetrieveResponseData>> {
+        return await this.axiosGet(`/groups/${id}/`, config);
+    }
+    
+    /** PUT /groups/{id}/ */
+    async update(id: string,data: GroupsType.GroupsUpdateRequestData,config?: RequestConfig
+    ): Promise<AxiosResponse<GroupsType.GroupsUpdateResponseData>> {
+        return await this.axiosPut(`/groups/${id}/`, data, config);
+    }
+    
+    /** PATCH /groups/{id}/ */
+    async partialUpdate(id: string,data: GroupsType.GroupsPartialupdateRequestData,config?: RequestConfig
+    ): Promise<AxiosResponse<GroupsType.GroupsPartialupdateResponseData>> {
+        return await this.axiosPatch(`/groups/${id}/`, data, config);
+    }
+    
+    /** DELETE /groups/{id}/ */
+    async delete(id: string,config?: RequestConfig
+    ): Promise<AxiosResponse<any>> {
+        return await this.axiosDelete(`/groups/${id}/`, config);
+    }
+    
+}

--- a/output/modules/health.ts
+++ b/output/modules/health.ts
@@ -1,0 +1,19 @@
+import * as HealthType from "../types/health";
+import { AxiosResponse } from "axios";
+import { Connection } from "../client/connection";
+import { BaseController } from "../utils/baseController";
+import { RequestConfig } from "../utils/globalTypes";
+
+export class HealthController extends BaseController {
+
+    constructor(connection: Connection, token?: string) {
+        super(connection, token);
+    }
+    
+    /** GET /health/ */
+    async list(config?: RequestConfig
+    ): Promise<AxiosResponse<HealthType.HealthListResponseData>> {
+        return await this.axiosGet(`/health/`, config);
+    }
+    
+}

--- a/output/modules/mushafs.ts
+++ b/output/modules/mushafs.ts
@@ -1,0 +1,62 @@
+import * as MushafsType from "../types/mushafs";
+import { AxiosResponse } from "axios";
+import { Connection } from "../client/connection";
+import { BaseController } from "../utils/baseController";
+import { RequestConfig } from "../utils/globalTypes";
+
+export class MushafsImport extends BaseController {
+    constructor(conn: Connection, token?: string) {
+        super(conn, token);
+    }
+    /** POST /mushafs/import/ */
+    async mushafs_import_create(config?: RequestConfig
+    ): Promise<AxiosResponse<MushafsType.MushafsImportResponseData>> {
+        return await this.axiosPost(`/mushafs/import/`, config);
+    }
+}
+
+export class MushafsController extends BaseController {
+    public readonly import: MushafsImport;
+
+    constructor(connection: Connection, token?: string) {
+        super(connection, token);
+        this.import = new MushafsImport(this.conn);
+    }
+    
+    /** GET /mushafs/ */
+    async list(config?: RequestConfig<MushafsType.MushafsListRequestParams>
+    ): Promise<AxiosResponse<MushafsType.MushafsListResponseData>> {
+        return await this.axiosGet(`/mushafs/`, config);
+    }
+    
+    /** POST /mushafs/ */
+    async create(data: MushafsType.MushafsCreateRequestData,config?: RequestConfig
+    ): Promise<AxiosResponse<MushafsType.MushafsCreateResponseData>> {
+        return await this.axiosPost(`/mushafs/`, data, config);
+    }
+    
+    /** GET /mushafs/{uuid}/ */
+    async retrieve(uuid: string,config?: RequestConfig
+    ): Promise<AxiosResponse<MushafsType.MushafsRetrieveResponseData>> {
+        return await this.axiosGet(`/mushafs/${uuid}/`, config);
+    }
+    
+    /** PUT /mushafs/{uuid}/ */
+    async update(uuid: string,data: MushafsType.MushafsUpdateRequestData,config?: RequestConfig
+    ): Promise<AxiosResponse<MushafsType.MushafsUpdateResponseData>> {
+        return await this.axiosPut(`/mushafs/${uuid}/`, data, config);
+    }
+    
+    /** PATCH /mushafs/{uuid}/ */
+    async partialUpdate(uuid: string,data: MushafsType.MushafsPartialupdateRequestData,config?: RequestConfig
+    ): Promise<AxiosResponse<MushafsType.MushafsPartialupdateResponseData>> {
+        return await this.axiosPatch(`/mushafs/${uuid}/`, data, config);
+    }
+    
+    /** DELETE /mushafs/{uuid}/ */
+    async delete(uuid: string,config?: RequestConfig
+    ): Promise<AxiosResponse<any>> {
+        return await this.axiosDelete(`/mushafs/${uuid}/`, config);
+    }
+    
+}

--- a/output/modules/notifications.ts
+++ b/output/modules/notifications.ts
@@ -1,0 +1,88 @@
+import * as NotificationsType from "../types/notifications";
+import { AxiosResponse } from "axios";
+import { Connection } from "../client/connection";
+import { BaseController } from "../utils/baseController";
+import { RequestConfig } from "../utils/globalTypes";
+
+export class NotificationsMe extends BaseController {
+    constructor(conn: Connection, token?: string) {
+        super(conn, token);
+    }
+    /** GET /notifications/me/ */
+    async notifications_me_list(config?: RequestConfig<NotificationsType.NotificationsMeRequestParams>
+    ): Promise<AxiosResponse<NotificationsType.NotificationsMeResponseData>> {
+        return await this.axiosGet(`/notifications/me/`, config);
+    }
+}
+
+export class NotificationsOpened extends BaseController {
+    constructor(conn: Connection, token?: string) {
+        super(conn, token);
+    }
+    /** GET /notifications/opened/ */
+    async notifications_opened_retrieve(config?: RequestConfig<NotificationsType.NotificationsOpenedRequestParams>
+    ): Promise<AxiosResponse<NotificationsType.NotificationsOpenedResponseData>> {
+        return await this.axiosGet(`/notifications/opened/`, config);
+    }
+}
+
+export class NotificationsViewed extends BaseController {
+    constructor(conn: Connection, token?: string) {
+        super(conn, token);
+    }
+    /** GET /notifications/viewed/ */
+    async notifications_viewed_retrieve(config?: RequestConfig
+    ): Promise<AxiosResponse<NotificationsType.NotificationsViewedResponseData>> {
+        return await this.axiosGet(`/notifications/viewed/`, config);
+    }
+}
+
+export class NotificationsController extends BaseController {
+    public readonly me: NotificationsMe;
+    public readonly opened: NotificationsOpened;
+    public readonly viewed: NotificationsViewed;
+
+    constructor(connection: Connection, token?: string) {
+        super(connection, token);
+        this.me = new NotificationsMe(this.conn);
+        this.opened = new NotificationsOpened(this.conn);
+        this.viewed = new NotificationsViewed(this.conn);
+    }
+    
+    /** GET /notifications/ */
+    async list(config?: RequestConfig<NotificationsType.NotificationsListRequestParams>
+    ): Promise<AxiosResponse<NotificationsType.NotificationsListResponseData>> {
+        return await this.axiosGet(`/notifications/`, config);
+    }
+    
+    /** POST /notifications/ */
+    async create(data: NotificationsType.NotificationsCreateRequestData,config?: RequestConfig
+    ): Promise<AxiosResponse<NotificationsType.NotificationsCreateResponseData>> {
+        return await this.axiosPost(`/notifications/`, data, config);
+    }
+    
+    /** GET /notifications/{id}/ */
+    async retrieve(id: string,config?: RequestConfig
+    ): Promise<AxiosResponse<NotificationsType.NotificationsRetrieveResponseData>> {
+        return await this.axiosGet(`/notifications/${id}/`, config);
+    }
+    
+    /** PUT /notifications/{id}/ */
+    async update(id: string,data: NotificationsType.NotificationsUpdateRequestData,config?: RequestConfig
+    ): Promise<AxiosResponse<NotificationsType.NotificationsUpdateResponseData>> {
+        return await this.axiosPut(`/notifications/${id}/`, data, config);
+    }
+    
+    /** PATCH /notifications/{id}/ */
+    async partialUpdate(id: string,data: NotificationsType.NotificationsPartialupdateRequestData,config?: RequestConfig
+    ): Promise<AxiosResponse<NotificationsType.NotificationsPartialupdateResponseData>> {
+        return await this.axiosPatch(`/notifications/${id}/`, data, config);
+    }
+    
+    /** DELETE /notifications/{id}/ */
+    async delete(id: string,config?: RequestConfig
+    ): Promise<AxiosResponse<any>> {
+        return await this.axiosDelete(`/notifications/${id}/`, config);
+    }
+    
+}

--- a/output/modules/phrases.ts
+++ b/output/modules/phrases.ts
@@ -1,0 +1,62 @@
+import * as PhrasesType from "../types/phrases";
+import { AxiosResponse } from "axios";
+import { Connection } from "../client/connection";
+import { BaseController } from "../utils/baseController";
+import { RequestConfig } from "../utils/globalTypes";
+
+export class PhrasesModify extends BaseController {
+    constructor(conn: Connection, token?: string) {
+        super(conn, token);
+    }
+    /** POST /phrases/modify/ */
+    async phrases_modify_create(data: PhrasesType.PhrasesModifyRequestData, config?: RequestConfig<PhrasesType.PhrasesModifyRequestParams>
+    ): Promise<AxiosResponse<PhrasesType.PhrasesModifyResponseData>> {
+        return await this.axiosPost(`/phrases/modify/`, data, config);
+    }
+}
+
+export class PhrasesController extends BaseController {
+    public readonly modify: PhrasesModify;
+
+    constructor(connection: Connection, token?: string) {
+        super(connection, token);
+        this.modify = new PhrasesModify(this.conn);
+    }
+    
+    /** GET /phrases/ */
+    async list(config?: RequestConfig
+    ): Promise<AxiosResponse<PhrasesType.PhrasesListResponseData>> {
+        return await this.axiosGet(`/phrases/`, config);
+    }
+    
+    /** POST /phrases/ */
+    async create(data: PhrasesType.PhrasesCreateRequestData,config?: RequestConfig
+    ): Promise<AxiosResponse<PhrasesType.PhrasesCreateResponseData>> {
+        return await this.axiosPost(`/phrases/`, data, config);
+    }
+    
+    /** GET /phrases/{uuid}/ */
+    async retrieve(uuid: string,config?: RequestConfig
+    ): Promise<AxiosResponse<PhrasesType.PhrasesRetrieveResponseData>> {
+        return await this.axiosGet(`/phrases/${uuid}/`, config);
+    }
+    
+    /** PUT /phrases/{uuid}/ */
+    async update(uuid: string,data: PhrasesType.PhrasesUpdateRequestData,config?: RequestConfig
+    ): Promise<AxiosResponse<PhrasesType.PhrasesUpdateResponseData>> {
+        return await this.axiosPut(`/phrases/${uuid}/`, data, config);
+    }
+    
+    /** PATCH /phrases/{uuid}/ */
+    async partialUpdate(uuid: string,data: PhrasesType.PhrasesPartialupdateRequestData,config?: RequestConfig
+    ): Promise<AxiosResponse<PhrasesType.PhrasesPartialupdateResponseData>> {
+        return await this.axiosPatch(`/phrases/${uuid}/`, data, config);
+    }
+    
+    /** DELETE /phrases/{uuid}/ */
+    async delete(uuid: string,config?: RequestConfig
+    ): Promise<AxiosResponse<any>> {
+        return await this.axiosDelete(`/phrases/${uuid}/`, config);
+    }
+    
+}

--- a/output/modules/profile.ts
+++ b/output/modules/profile.ts
@@ -1,0 +1,37 @@
+import * as ProfileType from "../types/profile";
+import { AxiosResponse } from "axios";
+import { Connection } from "../client/connection";
+import { BaseController } from "../utils/baseController";
+import { RequestConfig } from "../utils/globalTypes";
+
+export class ProfileMe extends BaseController {
+    constructor(conn: Connection, token?: string) {
+        super(conn, token);
+    }
+    /** GET /profile/me/ */
+    async profile_me_retrieve(config?: RequestConfig
+    ): Promise<AxiosResponse<ProfileType.ProfileMeResponseData>> {
+        return await this.axiosGet(`/profile/me/`, config);
+    }
+    /** POST /profile/me/ */
+    async profile_me_create(data: ProfileType.ProfileMeRequestData, config?: RequestConfig
+    ): Promise<AxiosResponse<ProfileType.ProfileMeResponseData>> {
+        return await this.axiosPost(`/profile/me/`, data, config);
+    }
+}
+
+export class ProfileController extends BaseController {
+    public readonly me: ProfileMe;
+
+    constructor(connection: Connection, token?: string) {
+        super(connection, token);
+        this.me = new ProfileMe(this.conn);
+    }
+    
+    /** GET /profile/{uuid}/ */
+    async retrieve(uuid: string,config?: RequestConfig
+    ): Promise<AxiosResponse<ProfileType.ProfileRetrieveResponseData>> {
+        return await this.axiosGet(`/profile/${uuid}/`, config);
+    }
+    
+}

--- a/output/modules/recitations.ts
+++ b/output/modules/recitations.ts
@@ -1,0 +1,49 @@
+import * as RecitationsType from "../types/recitations";
+import { AxiosResponse } from "axios";
+import { Connection } from "../client/connection";
+import { BaseController } from "../utils/baseController";
+import { RequestConfig } from "../utils/globalTypes";
+
+export class RecitationsController extends BaseController {
+
+    constructor(connection: Connection, token?: string) {
+        super(connection, token);
+    }
+    
+    /** GET /recitations/ */
+    async list(config?: RequestConfig<RecitationsType.RecitationsListRequestParams>
+    ): Promise<AxiosResponse<RecitationsType.RecitationsListResponseData>> {
+        return await this.axiosGet(`/recitations/`, config);
+    }
+    
+    /** POST /recitations/ */
+    async create(data: RecitationsType.RecitationsCreateRequestData,config?: RequestConfig
+    ): Promise<AxiosResponse<RecitationsType.RecitationsCreateResponseData>> {
+        return await this.axiosPost(`/recitations/`, data, config);
+    }
+    
+    /** GET /recitations/{uuid}/ */
+    async retrieve(uuid: string,config?: RequestConfig
+    ): Promise<AxiosResponse<RecitationsType.RecitationsRetrieveResponseData>> {
+        return await this.axiosGet(`/recitations/${uuid}/`, config);
+    }
+    
+    /** PUT /recitations/{uuid}/ */
+    async update(uuid: string,data: RecitationsType.RecitationsUpdateRequestData,config?: RequestConfig
+    ): Promise<AxiosResponse<RecitationsType.RecitationsUpdateResponseData>> {
+        return await this.axiosPut(`/recitations/${uuid}/`, data, config);
+    }
+    
+    /** PATCH /recitations/{uuid}/ */
+    async partialUpdate(uuid: string,data: RecitationsType.RecitationsPartialupdateRequestData,config?: RequestConfig
+    ): Promise<AxiosResponse<RecitationsType.RecitationsPartialupdateResponseData>> {
+        return await this.axiosPatch(`/recitations/${uuid}/`, data, config);
+    }
+    
+    /** DELETE /recitations/{uuid}/ */
+    async delete(uuid: string,config?: RequestConfig
+    ): Promise<AxiosResponse<any>> {
+        return await this.axiosDelete(`/recitations/${uuid}/`, config);
+    }
+    
+}

--- a/output/modules/surahs.ts
+++ b/output/modules/surahs.ts
@@ -1,0 +1,49 @@
+import * as SurahsType from "../types/surahs";
+import { AxiosResponse } from "axios";
+import { Connection } from "../client/connection";
+import { BaseController } from "../utils/baseController";
+import { RequestConfig } from "../utils/globalTypes";
+
+export class SurahsController extends BaseController {
+
+    constructor(connection: Connection, token?: string) {
+        super(connection, token);
+    }
+    
+    /** GET /surahs/ */
+    async list(config?: RequestConfig<SurahsType.SurahsListRequestParams>
+    ): Promise<AxiosResponse<SurahsType.SurahsListResponseData>> {
+        return await this.axiosGet(`/surahs/`, config);
+    }
+    
+    /** POST /surahs/ */
+    async create(data: SurahsType.SurahsCreateRequestData,config?: RequestConfig
+    ): Promise<AxiosResponse<SurahsType.SurahsCreateResponseData>> {
+        return await this.axiosPost(`/surahs/`, data, config);
+    }
+    
+    /** GET /surahs/{uuid}/ */
+    async retrieve(uuid: string,config?: RequestConfig
+    ): Promise<AxiosResponse<SurahsType.SurahsRetrieveResponseData>> {
+        return await this.axiosGet(`/surahs/${uuid}/`, config);
+    }
+    
+    /** PUT /surahs/{uuid}/ */
+    async update(uuid: string,data: SurahsType.SurahsUpdateRequestData,config?: RequestConfig
+    ): Promise<AxiosResponse<SurahsType.SurahsUpdateResponseData>> {
+        return await this.axiosPut(`/surahs/${uuid}/`, data, config);
+    }
+    
+    /** PATCH /surahs/{uuid}/ */
+    async partialUpdate(uuid: string,data: SurahsType.SurahsPartialupdateRequestData,config?: RequestConfig
+    ): Promise<AxiosResponse<SurahsType.SurahsPartialupdateResponseData>> {
+        return await this.axiosPatch(`/surahs/${uuid}/`, data, config);
+    }
+    
+    /** DELETE /surahs/{uuid}/ */
+    async delete(uuid: string,config?: RequestConfig
+    ): Promise<AxiosResponse<any>> {
+        return await this.axiosDelete(`/surahs/${uuid}/`, config);
+    }
+    
+}

--- a/output/modules/takhtits.ts
+++ b/output/modules/takhtits.ts
@@ -1,0 +1,49 @@
+import * as TakhtitsType from "../types/takhtits";
+import { AxiosResponse } from "axios";
+import { Connection } from "../client/connection";
+import { BaseController } from "../utils/baseController";
+import { RequestConfig } from "../utils/globalTypes";
+
+export class TakhtitsController extends BaseController {
+
+    constructor(connection: Connection, token?: string) {
+        super(connection, token);
+    }
+    
+    /** GET /takhtits/ */
+    async list(config?: RequestConfig<TakhtitsType.TakhtitsListRequestParams>
+    ): Promise<AxiosResponse<TakhtitsType.TakhtitsListResponseData>> {
+        return await this.axiosGet(`/takhtits/`, config);
+    }
+    
+    /** POST /takhtits/ */
+    async create(data: TakhtitsType.TakhtitsCreateRequestData,config?: RequestConfig
+    ): Promise<AxiosResponse<TakhtitsType.TakhtitsCreateResponseData>> {
+        return await this.axiosPost(`/takhtits/`, data, config);
+    }
+    
+    /** GET /takhtits/{uuid}/ */
+    async retrieve(uuid: string,config?: RequestConfig
+    ): Promise<AxiosResponse<TakhtitsType.TakhtitsRetrieveResponseData>> {
+        return await this.axiosGet(`/takhtits/${uuid}/`, config);
+    }
+    
+    /** PUT /takhtits/{uuid}/ */
+    async update(uuid: string,data: TakhtitsType.TakhtitsUpdateRequestData,config?: RequestConfig
+    ): Promise<AxiosResponse<TakhtitsType.TakhtitsUpdateResponseData>> {
+        return await this.axiosPut(`/takhtits/${uuid}/`, data, config);
+    }
+    
+    /** PATCH /takhtits/{uuid}/ */
+    async partialUpdate(uuid: string,data: TakhtitsType.TakhtitsPartialupdateRequestData,config?: RequestConfig
+    ): Promise<AxiosResponse<TakhtitsType.TakhtitsPartialupdateResponseData>> {
+        return await this.axiosPatch(`/takhtits/${uuid}/`, data, config);
+    }
+    
+    /** DELETE /takhtits/{uuid}/ */
+    async delete(uuid: string,config?: RequestConfig
+    ): Promise<AxiosResponse<any>> {
+        return await this.axiosDelete(`/takhtits/${uuid}/`, config);
+    }
+    
+}

--- a/output/modules/translations.ts
+++ b/output/modules/translations.ts
@@ -1,0 +1,62 @@
+import * as TranslationsType from "../types/translations";
+import { AxiosResponse } from "axios";
+import { Connection } from "../client/connection";
+import { BaseController } from "../utils/baseController";
+import { RequestConfig } from "../utils/globalTypes";
+
+export class TranslationsImport extends BaseController {
+    constructor(conn: Connection, token?: string) {
+        super(conn, token);
+    }
+    /** POST /translations/import/ */
+    async translations_import_create(config?: RequestConfig
+    ): Promise<AxiosResponse<TranslationsType.TranslationsImportResponseData>> {
+        return await this.axiosPost(`/translations/import/`, config);
+    }
+}
+
+export class TranslationsController extends BaseController {
+    public readonly import: TranslationsImport;
+
+    constructor(connection: Connection, token?: string) {
+        super(connection, token);
+        this.import = new TranslationsImport(this.conn);
+    }
+    
+    /** GET /translations/ */
+    async list(config?: RequestConfig<TranslationsType.TranslationsListRequestParams>
+    ): Promise<AxiosResponse<TranslationsType.TranslationsListResponseData>> {
+        return await this.axiosGet(`/translations/`, config);
+    }
+    
+    /** POST /translations/ */
+    async create(data: TranslationsType.TranslationsCreateRequestData,config?: RequestConfig
+    ): Promise<AxiosResponse<TranslationsType.TranslationsCreateResponseData>> {
+        return await this.axiosPost(`/translations/`, data, config);
+    }
+    
+    /** GET /translations/{uuid}/ */
+    async retrieve(uuid: string,config?: RequestConfig
+    ): Promise<AxiosResponse<TranslationsType.TranslationsRetrieveResponseData>> {
+        return await this.axiosGet(`/translations/${uuid}/`, config);
+    }
+    
+    /** PUT /translations/{uuid}/ */
+    async update(uuid: string,data: TranslationsType.TranslationsUpdateRequestData,config?: RequestConfig
+    ): Promise<AxiosResponse<TranslationsType.TranslationsUpdateResponseData>> {
+        return await this.axiosPut(`/translations/${uuid}/`, data, config);
+    }
+    
+    /** PATCH /translations/{uuid}/ */
+    async partialUpdate(uuid: string,data: TranslationsType.TranslationsPartialupdateRequestData,config?: RequestConfig
+    ): Promise<AxiosResponse<TranslationsType.TranslationsPartialupdateResponseData>> {
+        return await this.axiosPatch(`/translations/${uuid}/`, data, config);
+    }
+    
+    /** DELETE /translations/{uuid}/ */
+    async delete(uuid: string,config?: RequestConfig
+    ): Promise<AxiosResponse<any>> {
+        return await this.axiosDelete(`/translations/${uuid}/`, config);
+    }
+    
+}

--- a/output/modules/users.ts
+++ b/output/modules/users.ts
@@ -1,0 +1,49 @@
+import * as UsersType from "../types/users";
+import { AxiosResponse } from "axios";
+import { Connection } from "../client/connection";
+import { BaseController } from "../utils/baseController";
+import { RequestConfig } from "../utils/globalTypes";
+
+export class UsersController extends BaseController {
+
+    constructor(connection: Connection, token?: string) {
+        super(connection, token);
+    }
+    
+    /** GET /users/ */
+    async list(config?: RequestConfig
+    ): Promise<AxiosResponse<UsersType.UsersListResponseData>> {
+        return await this.axiosGet(`/users/`, config);
+    }
+    
+    /** POST /users/ */
+    async create(data: UsersType.UsersCreateRequestData,config?: RequestConfig
+    ): Promise<AxiosResponse<UsersType.UsersCreateResponseData>> {
+        return await this.axiosPost(`/users/`, data, config);
+    }
+    
+    /** GET /users/{uuid}/ */
+    async retrieve(uuid: string,config?: RequestConfig
+    ): Promise<AxiosResponse<UsersType.UsersRetrieveResponseData>> {
+        return await this.axiosGet(`/users/${uuid}/`, config);
+    }
+    
+    /** PUT /users/{uuid}/ */
+    async update(uuid: string,data: UsersType.UsersUpdateRequestData,config?: RequestConfig
+    ): Promise<AxiosResponse<UsersType.UsersUpdateResponseData>> {
+        return await this.axiosPut(`/users/${uuid}/`, data, config);
+    }
+    
+    /** PATCH /users/{uuid}/ */
+    async partialUpdate(uuid: string,data: UsersType.UsersPartialupdateRequestData,config?: RequestConfig
+    ): Promise<AxiosResponse<UsersType.UsersPartialupdateResponseData>> {
+        return await this.axiosPatch(`/users/${uuid}/`, data, config);
+    }
+    
+    /** DELETE /users/{uuid}/ */
+    async delete(uuid: string,config?: RequestConfig
+    ): Promise<AxiosResponse<any>> {
+        return await this.axiosDelete(`/users/${uuid}/`, config);
+    }
+    
+}

--- a/output/modules/words.ts
+++ b/output/modules/words.ts
@@ -1,0 +1,49 @@
+import * as WordsType from "../types/words";
+import { AxiosResponse } from "axios";
+import { Connection } from "../client/connection";
+import { BaseController } from "../utils/baseController";
+import { RequestConfig } from "../utils/globalTypes";
+
+export class WordsController extends BaseController {
+
+    constructor(connection: Connection, token?: string) {
+        super(connection, token);
+    }
+    
+    /** GET /words/ */
+    async list(config?: RequestConfig<WordsType.WordsListRequestParams>
+    ): Promise<AxiosResponse<WordsType.WordsListResponseData>> {
+        return await this.axiosGet(`/words/`, config);
+    }
+    
+    /** POST /words/ */
+    async create(data: WordsType.WordsCreateRequestData,config?: RequestConfig<WordsType.WordsCreateRequestParams>
+    ): Promise<AxiosResponse<WordsType.WordsCreateResponseData>> {
+        return await this.axiosPost(`/words/`, data, config);
+    }
+    
+    /** GET /words/{uuid}/ */
+    async retrieve(uuid: string,config?: RequestConfig
+    ): Promise<AxiosResponse<WordsType.WordsRetrieveResponseData>> {
+        return await this.axiosGet(`/words/${uuid}/`, config);
+    }
+    
+    /** PUT /words/{uuid}/ */
+    async update(uuid: string,data: WordsType.WordsUpdateRequestData,config?: RequestConfig
+    ): Promise<AxiosResponse<WordsType.WordsUpdateResponseData>> {
+        return await this.axiosPut(`/words/${uuid}/`, data, config);
+    }
+    
+    /** PATCH /words/{uuid}/ */
+    async partialUpdate(uuid: string,data: WordsType.WordsPartialupdateRequestData,config?: RequestConfig
+    ): Promise<AxiosResponse<WordsType.WordsPartialupdateResponseData>> {
+        return await this.axiosPatch(`/words/${uuid}/`, data, config);
+    }
+    
+    /** DELETE /words/{uuid}/ */
+    async delete(uuid: string,config?: RequestConfig
+    ): Promise<AxiosResponse<any>> {
+        return await this.axiosDelete(`/words/${uuid}/`, config);
+    }
+    
+}

--- a/output/types/auth.ts
+++ b/output/types/auth.ts
@@ -1,0 +1,23 @@
+
+export interface AuthLoginRequestData {
+    password: string;
+    username: string;
+}
+export interface AuthLoginResponseData {
+    expiry: string;
+    token: string;
+    user: object;
+}
+export interface AuthRegisterRequestData {
+    email: string;
+    first_name?: string;
+    last_name?: string;
+    password: string;
+    password2: string;
+    username: string;
+}
+export interface AuthRegisterResponseData {
+    token: string;
+    user: object;
+}
+

--- a/output/types/ayahs.ts
+++ b/output/types/ayahs.ts
@@ -1,0 +1,79 @@
+
+export type AyahsListResponseData = Ayah[];
+export interface AyahsListRequestParams {
+    limit?: number;
+    offset?: number;
+    ordering?: string;
+    search?: string;
+    surah_uuid?: string;
+}
+export interface AyahsCreateRequestData {
+    bismillah_text?: string;
+    is_bismillah?: boolean;
+    sajdah?: string;
+    surah_uuid: string;
+    text: string;
+}
+export interface AyahsCreateResponseData {
+    bismillah_text?: string;
+    is_bismillah?: boolean;
+    sajdah?: string;
+    surah_uuid: string;
+    text: string;
+}
+export interface AyahsRetrieveResponseData {
+    bismillah: string;
+    breakers: string;
+    mushaf: string;
+    number: number;
+    sajdah?: string;
+    surah: object;
+    text: string;
+    uuid: string;
+    words: Word[];
+}
+export interface AyahsUpdateRequestData {
+    number: number;
+    sajdah?: string;
+}
+export interface AyahsUpdateResponseData {
+    bismillah: string;
+    breakers: string;
+    number: number;
+    sajdah?: string;
+    surah: string;
+    text: string;
+    uuid: string;
+}
+export interface AyahsPartialupdateRequestData {
+    number?: number;
+    sajdah?: string;
+}
+export interface AyahsPartialupdateResponseData {
+    bismillah: string;
+    breakers: string;
+    number: number;
+    sajdah?: string;
+    surah: string;
+    text: string;
+    uuid: string;
+}
+
+
+export interface Ayah {
+    uuid: string;
+    number: number;
+    text: string;
+    bismillah?: string;
+    breakers?: string;
+    sajdah?: string;
+    surah?: string;
+}
+
+export interface AyahTranslation {
+    uuid: string;
+    text: string;
+    ayah_uuid: string;
+    translation_uuid: string;
+    bismillah?: string;
+}

--- a/output/types/groups.ts
+++ b/output/types/groups.ts
@@ -1,0 +1,34 @@
+
+export type GroupsListResponseData = Group[];
+export interface GroupsCreateRequestData {
+    name: string;
+}
+export interface GroupsCreateResponseData {
+    name: string;
+    url: string;
+}
+export interface GroupsRetrieveResponseData {
+    name: string;
+    url: string;
+}
+export interface GroupsUpdateRequestData {
+    name: string;
+}
+export interface GroupsUpdateResponseData {
+    name: string;
+    url: string;
+}
+export interface GroupsPartialupdateRequestData {
+    name?: string;
+}
+export interface GroupsPartialupdateResponseData {
+    name: string;
+    url: string;
+}
+
+
+export interface Group {
+    uuid: string;
+    name: string;
+    url?: string;
+}

--- a/output/types/health.ts
+++ b/output/types/health.ts
@@ -1,0 +1,6 @@
+
+export interface HealthListResponseData {
+    services?: object;
+    status: string;
+}
+

--- a/output/types/mushafs.ts
+++ b/output/types/mushafs.ts
@@ -1,0 +1,70 @@
+
+export interface MushafsImportResponseData {
+    name: string;
+    short_name: string;
+    source?: string;
+    status?: 'draft' | 'pending_review' | 'published';
+    uuid: string;
+}
+export type MushafsListResponseData = Mushaf[];
+export interface MushafsListRequestParams {
+    limit?: number;
+    offset?: number;
+    ordering?: string;
+    search?: string;
+}
+export interface MushafsCreateRequestData {
+    name: string;
+    short_name: string;
+    source?: string;
+    status?: 'draft' | 'pending_review' | 'published';
+}
+export interface MushafsCreateResponseData {
+    name: string;
+    short_name: string;
+    source?: string;
+    status?: 'draft' | 'pending_review' | 'published';
+    uuid: string;
+}
+export interface MushafsRetrieveResponseData {
+    name: string;
+    short_name: string;
+    source?: string;
+    status?: 'draft' | 'pending_review' | 'published';
+    uuid: string;
+}
+export interface MushafsUpdateRequestData {
+    name: string;
+    short_name: string;
+    source?: string;
+    status?: 'draft' | 'pending_review' | 'published';
+}
+export interface MushafsUpdateResponseData {
+    name: string;
+    short_name: string;
+    source?: string;
+    status?: 'draft' | 'pending_review' | 'published';
+    uuid: string;
+}
+export interface MushafsPartialupdateRequestData {
+    name?: string;
+    short_name?: string;
+    source?: string;
+    status?: 'draft' | 'pending_review' | 'published';
+}
+export interface MushafsPartialupdateResponseData {
+    name: string;
+    short_name: string;
+    source?: string;
+    status?: 'draft' | 'pending_review' | 'published';
+    uuid: string;
+}
+
+
+export interface Mushaf {
+    uuid: string;
+    name: string;
+    short_name: string;
+    source?: string;
+    status?: 'draft' | 'pending_review' | 'published';
+}

--- a/output/types/notifications.ts
+++ b/output/types/notifications.ts
@@ -1,0 +1,102 @@
+
+export type NotificationsMeResponseData = Notification[];
+export interface NotificationsMeRequestParams {
+    limit?: number;
+    offset?: number;
+}
+export interface NotificationsOpenedResponseData {
+}
+export interface NotificationsOpenedRequestParams {
+    uuid: string;
+}
+export interface NotificationsViewedResponseData {
+}
+export type NotificationsListResponseData = Notification[];
+export interface NotificationsListRequestParams {
+    limit?: number;
+    offset?: number;
+}
+export interface NotificationsCreateRequestData {
+    description?: string;
+    message?: string;
+    message_type?: 'success' | 'failed' | 'warning' | 'pending';
+    resource_action: string;
+    resource_controller: string;
+    resource_uuid?: string;
+    status?: 'nothing_happened' | 'got_notification' | 'viewed_notification' | 'opened_notification';
+}
+export interface NotificationsCreateResponseData {
+    created_at: string;
+    description?: string;
+    message?: string;
+    message_type?: 'success' | 'failed' | 'warning' | 'pending';
+    resource_action: string;
+    resource_controller: string;
+    resource_uuid?: string;
+    status?: 'nothing_happened' | 'got_notification' | 'viewed_notification' | 'opened_notification';
+    uuid: string;
+}
+export interface NotificationsRetrieveResponseData {
+    created_at: string;
+    description?: string;
+    message?: string;
+    message_type?: 'success' | 'failed' | 'warning' | 'pending';
+    resource_action: string;
+    resource_controller: string;
+    resource_uuid?: string;
+    status?: 'nothing_happened' | 'got_notification' | 'viewed_notification' | 'opened_notification';
+    uuid: string;
+}
+export interface NotificationsUpdateRequestData {
+    description?: string;
+    message?: string;
+    message_type?: 'success' | 'failed' | 'warning' | 'pending';
+    resource_action: string;
+    resource_controller: string;
+    resource_uuid?: string;
+    status?: 'nothing_happened' | 'got_notification' | 'viewed_notification' | 'opened_notification';
+}
+export interface NotificationsUpdateResponseData {
+    created_at: string;
+    description?: string;
+    message?: string;
+    message_type?: 'success' | 'failed' | 'warning' | 'pending';
+    resource_action: string;
+    resource_controller: string;
+    resource_uuid?: string;
+    status?: 'nothing_happened' | 'got_notification' | 'viewed_notification' | 'opened_notification';
+    uuid: string;
+}
+export interface NotificationsPartialupdateRequestData {
+    description?: string;
+    message?: string;
+    message_type?: 'success' | 'failed' | 'warning' | 'pending';
+    resource_action?: string;
+    resource_controller?: string;
+    resource_uuid?: string;
+    status?: 'nothing_happened' | 'got_notification' | 'viewed_notification' | 'opened_notification';
+}
+export interface NotificationsPartialupdateResponseData {
+    created_at: string;
+    description?: string;
+    message?: string;
+    message_type?: 'success' | 'failed' | 'warning' | 'pending';
+    resource_action: string;
+    resource_controller: string;
+    resource_uuid?: string;
+    status?: 'nothing_happened' | 'got_notification' | 'viewed_notification' | 'opened_notification';
+    uuid: string;
+}
+
+
+export interface Notification {
+    uuid: string;
+    message?: string;
+    message_type?: 'success' | 'failed' | 'warning' | 'pending';
+    description?: string;
+    resource_controller: string;
+    resource_action: string;
+    resource_uuid?: string;
+    status?: 'nothing_happened' | 'got_notification' | 'viewed_notification' | 'opened_notification';
+    created_at: string;
+}

--- a/output/types/phrases.ts
+++ b/output/types/phrases.ts
@@ -1,0 +1,42 @@
+
+export interface PhrasesModifyRequestData {
+    phrases: object;
+}
+export interface PhrasesModifyResponseData {
+    phrases: object;
+}
+export interface PhrasesModifyRequestParams {
+    language: string;
+}
+export type PhrasesListResponseData = Phrase[];
+export interface PhrasesCreateRequestData {
+    phrase: string;
+}
+export interface PhrasesCreateResponseData {
+    phrase: string;
+    uuid: string;
+}
+export interface PhrasesRetrieveResponseData {
+    phrase: string;
+    uuid: string;
+}
+export interface PhrasesUpdateRequestData {
+    phrase: string;
+}
+export interface PhrasesUpdateResponseData {
+    phrase: string;
+    uuid: string;
+}
+export interface PhrasesPartialupdateRequestData {
+    phrase?: string;
+}
+export interface PhrasesPartialupdateResponseData {
+    phrase: string;
+    uuid: string;
+}
+
+
+export interface Phrase {
+    uuid: string;
+    phrase: string;
+}

--- a/output/types/profile.ts
+++ b/output/types/profile.ts
@@ -1,0 +1,26 @@
+
+export interface ProfileMeResponseData {
+    email?: string;
+    first_name?: string;
+    last_name?: string;
+    username: string;
+}
+export interface ProfileMeRequestData {
+    email?: string;
+    first_name?: string;
+    last_name?: string;
+    username: string;
+}
+export interface ProfileMeResponseData {
+    email?: string;
+    first_name?: string;
+    last_name?: string;
+    username: string;
+}
+export interface ProfileRetrieveResponseData {
+    email?: string;
+    first_name?: string;
+    last_name?: string;
+    username: string;
+}
+

--- a/output/types/recitations.ts
+++ b/output/types/recitations.ts
@@ -1,0 +1,105 @@
+
+export type RecitationsListResponseData = RecitationList[];
+export interface RecitationsListRequestParams {
+    limit?: number;
+    mushaf: string;
+    offset?: number;
+    ordering?: string;
+    reciter_uuid?: string;
+    search?: string;
+}
+export interface RecitationsCreateRequestData {
+    duration: string;
+    mushaf_uuid: string;
+    recitation_date: string;
+    recitation_location: string;
+    recitation_type: string;
+    reciter_account_uuid: string;
+    status?: 'draft' | 'pending_review' | 'published';
+}
+export interface RecitationsCreateResponseData {
+    ayahs_timestamps: string;
+    created_at: string;
+    duration: string;
+    get_mushaf_uuid: string;
+    recitation_date: string;
+    recitation_location: string;
+    recitation_type: string;
+    status?: 'draft' | 'pending_review' | 'published';
+    updated_at: string;
+    uuid: string;
+    words_timestamps: string;
+}
+export interface RecitationsRetrieveResponseData {
+    ayahs_timestamps: string;
+    created_at: string;
+    duration: string;
+    get_mushaf_uuid: string;
+    recitation_date: string;
+    recitation_location: string;
+    recitation_type: string;
+    status?: 'draft' | 'pending_review' | 'published';
+    updated_at: string;
+    uuid: string;
+    words_timestamps: string;
+}
+export interface RecitationsUpdateRequestData {
+    duration: string;
+    mushaf_uuid: string;
+    recitation_date: string;
+    recitation_location: string;
+    recitation_type: string;
+    reciter_account_uuid: string;
+    status?: 'draft' | 'pending_review' | 'published';
+}
+export interface RecitationsUpdateResponseData {
+    ayahs_timestamps: string;
+    created_at: string;
+    duration: string;
+    get_mushaf_uuid: string;
+    recitation_date: string;
+    recitation_location: string;
+    recitation_type: string;
+    status?: 'draft' | 'pending_review' | 'published';
+    updated_at: string;
+    uuid: string;
+    words_timestamps: string;
+}
+export interface RecitationsPartialupdateRequestData {
+    duration?: string;
+    mushaf_uuid?: string;
+    recitation_date?: string;
+    recitation_location?: string;
+    recitation_type?: string;
+    reciter_account_uuid?: string;
+    status?: 'draft' | 'pending_review' | 'published';
+}
+export interface RecitationsPartialupdateResponseData {
+    ayahs_timestamps: string;
+    created_at: string;
+    duration: string;
+    get_mushaf_uuid: string;
+    recitation_date: string;
+    recitation_location: string;
+    recitation_type: string;
+    status?: 'draft' | 'pending_review' | 'published';
+    updated_at: string;
+    uuid: string;
+    words_timestamps: string;
+}
+export interface RecitationsRecitations_upload_createResponseData {
+}
+
+
+export interface RecitationList {
+    uuid: string;
+    recitation_date: string;
+    recitation_location: string;
+    recitation_type: string;
+    duration: string;
+    status?: 'draft' | 'pending_review' | 'published';
+    reciter_account_uuid: string;
+    mushaf_uuid: string;
+    created_at: string;
+    updated_at: string;
+}

--- a/output/types/surahs.ts
+++ b/output/types/surahs.ts
@@ -1,0 +1,95 @@
+
+export type SurahsListResponseData = Surah[];
+export interface SurahsListRequestParams {
+    limit?: number;
+    mushaf: string;
+    offset?: number;
+    ordering?: string;
+    search?: string;
+}
+export interface SurahsCreateRequestData {
+    mushaf_uuid: string;
+    name: string;
+    number: number;
+    period?: 'makki' | 'madani';
+    search_terms?: string;
+}
+export interface SurahsCreateResponseData {
+    bismillah: string;
+    mushaf: object;
+    names: string;
+    number: number;
+    number_of_ayahs: string;
+    period?: 'makki' | 'madani';
+    search_terms?: string;
+    uuid: string;
+}
+export interface SurahsRetrieveResponseData {
+    ayahs: AyahInSurah[];
+    bismillah: string;
+    mushaf: object;
+    names: string;
+    number: number;
+    number_of_ayahs: string;
+    period?: 'makki' | 'madani';
+    search_terms?: string;
+    uuid: string;
+}
+export interface SurahsUpdateRequestData {
+    mushaf_uuid: string;
+    name: string;
+    number: number;
+    period?: 'makki' | 'madani';
+    search_terms?: string;
+}
+export interface SurahsUpdateResponseData {
+    bismillah: string;
+    mushaf: object;
+    names: string;
+    number: number;
+    number_of_ayahs: string;
+    period?: 'makki' | 'madani';
+    search_terms?: string;
+    uuid: string;
+}
+export interface SurahsPartialupdateRequestData {
+    mushaf_uuid?: string;
+    name?: string;
+    number?: number;
+    period?: 'makki' | 'madani';
+    search_terms?: string;
+}
+export interface SurahsPartialupdateResponseData {
+    bismillah: string;
+    mushaf: object;
+    names: string;
+    number: number;
+    number_of_ayahs: string;
+    period?: 'makki' | 'madani';
+    search_terms?: string;
+    uuid: string;
+}
+
+
+export interface Surah {
+    uuid: string;
+    name: string;
+    names: string;
+    number: number;
+    number_of_ayahs: string;
+    bismillah: string;
+    period?: 'makki' | 'madani';
+    search_terms?: string;
+    mushaf: object;
+    mushaf_uuid: string;
+}
+
+export interface Ayah {
+    uuid: string;
+    number: number;
+    text: string;
+    bismillah?: string;
+    breakers?: string;
+    sajdah?: string;
+    surah?: string;
+}

--- a/output/types/takhtits.ts
+++ b/output/types/takhtits.ts
@@ -1,0 +1,97 @@
+
+export type TakhtitsListResponseData = Takhtit[];
+export interface TakhtitsListRequestParams {
+    mushaf?: string;
+}
+export interface TakhtitsCreateRequestData {
+    account_uuid: string;
+    mushaf_uuid: string;
+}
+export interface TakhtitsCreateResponseData {
+    account: number;
+    created_at: string;
+    creator: number;
+    mushaf: number;
+    uuid: string;
+}
+export interface TakhtitsRetrieveResponseData {
+    account: number;
+    created_at: string;
+    creator: number;
+    mushaf: number;
+    uuid: string;
+}
+export interface TakhtitsUpdateRequestData {
+    account: number;
+    mushaf: number;
+}
+export interface TakhtitsUpdateResponseData {
+    account: number;
+    created_at: string;
+    creator: number;
+    mushaf: number;
+    uuid: string;
+}
+export interface TakhtitsPartialupdateRequestData {
+    account?: number;
+    mushaf?: number;
+}
+export interface TakhtitsPartialupdateResponseData {
+    account: number;
+    created_at: string;
+    creator: number;
+    mushaf: number;
+    uuid: string;
+}
+export type TakhtitsTakhtits_ayahs_breakers_listResponseData = AyahBreakersResponse[];
+export interface TakhtitsTakhtits_ayahs_breakers_createRequestData {
+    ayah_uuid: string;
+    type: string;
+}
+export interface TakhtitsTakhtits_ayahs_breakers_createResponseData {
+    type: 'page' | 'juz' | 'hizb' | 'rub' | 'manzil' | 'ruku';
+    uuid: string;
+}
+export interface TakhtitsTakhtits_ayahs_breakers_retrieveResponseData {
+    type: 'page' | 'juz' | 'hizb' | 'rub' | 'manzil' | 'ruku';
+    uuid: string;
+}
+export interface TakhtitsTakhtits_import_createResponseData {
+}
+export interface TakhtitsTakhtits_import_createRequestParams {
+    type?: string;
+}
+export type TakhtitsTakhtits_words_breakers_listResponseData = WordBreakersResponse[];
+export interface TakhtitsTakhtits_words_breakers_createRequestData {
+    type: string;
+    word_uuid: string;
+}
+export interface TakhtitsTakhtits_words_breakers_createResponseData {
+    type: string;
+    word_uuid: string;
+}
+export interface TakhtitsTakhtits_words_breakers_retrieveResponseData {
+    type: string;
+    word_uuid: string;
+}
+
+
+export interface Takhtit {
+    uuid: string;
+    account: number;
+    creator: number;
+    mushaf: number;
+    created_at: string;
+}
+
+export interface AyahBreakersResponse {
+    uuid: string;
+    type: 'page' | 'juz' | 'hizb' | 'rub' | 'manzil' | 'ruku';
+    ayah_uuid: string;
+}
+
+export interface WordBreakersResponse {
+    uuid: string;
+    type: string;
+    word_uuid: string;
+}

--- a/output/types/translations.ts
+++ b/output/types/translations.ts
@@ -1,0 +1,115 @@
+
+export interface TranslationsImportResponseData {
+    language: string;
+    mushaf_uuid: string;
+    release_date?: string;
+    source?: string;
+    status?: 'draft' | 'pending_review' | 'published';
+    translator_uuid: string;
+    uuid: string;
+}
+export type TranslationsListResponseData = TranslationList[];
+export interface TranslationsListRequestParams {
+    language?: string;
+    limit?: number;
+    mushaf: string;
+    offset?: number;
+    ordering?: string;
+    search?: string;
+}
+export interface TranslationsCreateRequestData {
+    language: string;
+    release_date?: string;
+    source?: string;
+    status?: 'draft' | 'pending_review' | 'published';
+}
+export interface TranslationsCreateResponseData {
+    language: string;
+    mushaf_uuid: string;
+    release_date?: string;
+    source?: string;
+    status?: 'draft' | 'pending_review' | 'published';
+    translator_uuid: string;
+    uuid: string;
+}
+export interface TranslationsRetrieveResponseData {
+    language: 'ar' | 'en' | 'fr' | 'ur' | 'tr' | 'id' | 'fa' | 'ru' | 'es' | 'de' | 'bn' | 'zh' | 'ms' | 'hi' | 'sw' | 'ps' | 'ku' | 'az' | 'ha' | 'so' | 'ta' | 'te' | 'ml' | 'pa' | 'sd' | 'ug' | 'uz' | 'kk' | 'ky' | 'tk' | 'tg' | 'syr' | 'ber' | 'am' | 'om' | 'wo' | 'yo' | 'other';
+    mushaf_uuid: string;
+    release_date?: string;
+    source?: string;
+    status?: 'draft' | 'pending_review' | 'published';
+    translator_uuid: string;
+    uuid: string;
+}
+export interface TranslationsUpdateRequestData {
+    language: string;
+    release_date?: string;
+    source?: string;
+    status?: 'draft' | 'pending_review' | 'published';
+}
+export interface TranslationsUpdateResponseData {
+    language: string;
+    mushaf_uuid: string;
+    release_date?: string;
+    source?: string;
+    status?: 'draft' | 'pending_review' | 'published';
+    translator_uuid: string;
+    uuid: string;
+}
+export interface TranslationsPartialupdateRequestData {
+    language?: string;
+    release_date?: string;
+    source?: string;
+    status?: 'draft' | 'pending_review' | 'published';
+}
+export interface TranslationsPartialupdateResponseData {
+    language: string;
+    mushaf_uuid: string;
+    release_date?: string;
+    source?: string;
+    status?: 'draft' | 'pending_review' | 'published';
+    translator_uuid: string;
+    uuid: string;
+}
+export type TranslationsTranslations_ayahs_listResponseData = AyahTranslation[];
+export interface TranslationsTranslations_ayahs_listRequestParams {
+    limit?: number;
+    offset?: number;
+    ordering?: string;
+    search?: string;
+    surah_uuid?: string;
+}
+export interface TranslationsTranslations_ayahs_retrieveResponseData {
+    bismillah?: string;
+    text: string;
+    uuid: string;
+}
+export interface TranslationsTranslations_ayahs_createRequestData {
+    bismillah?: boolean;
+    text: string;
+}
+export interface TranslationsTranslations_ayahs_createResponseData {
+    bismillah?: string;
+    text: string;
+    uuid: string;
+}
+export interface TranslationsTranslations_ayahs_updateRequestData {
+    bismillah?: boolean;
+    text: string;
+}
+export interface TranslationsTranslations_ayahs_updateResponseData {
+    bismillah?: string;
+    text: string;
+    uuid: string;
+}
+
+
+export interface TranslationList {
+    uuid: string;
+    language: string;
+    source?: string;
+    release_date?: string;
+    status?: 'draft' | 'pending_review' | 'published';
+    translator_uuid: string;
+    mushaf_uuid: string;
+}

--- a/output/types/users.ts
+++ b/output/types/users.ts
@@ -1,0 +1,61 @@
+
+export type UsersListResponseData = User[];
+export interface UsersCreateRequestData {
+    email: string;
+    first_name?: string;
+    last_name?: string;
+    password: string;
+    password2: string;
+    username: string;
+}
+export interface UsersCreateResponseData {
+    email: string;
+    first_name?: string;
+    last_name?: string;
+    username: string;
+}
+export interface UsersRetrieveResponseData {
+    email: string;
+    first_name?: string;
+    last_name?: string;
+    username: string;
+}
+export interface UsersUpdateRequestData {
+    email: string;
+    first_name?: string;
+    last_name?: string;
+    password: string;
+    password2: string;
+    username: string;
+}
+export interface UsersUpdateResponseData {
+    email: string;
+    first_name?: string;
+    last_name?: string;
+    username: string;
+}
+export interface UsersPartialupdateRequestData {
+    email?: string;
+    first_name?: string;
+    last_name?: string;
+    password?: string;
+    password2?: string;
+    username?: string;
+}
+export interface UsersPartialupdateResponseData {
+    email: string;
+    first_name?: string;
+    last_name?: string;
+    username: string;
+}
+
+
+export interface User {
+    uuid: string;
+    username: string;
+    email: string;
+    first_name?: string;
+    last_name?: string;
+    password: string;
+    password2: string;
+}

--- a/output/types/words.ts
+++ b/output/types/words.ts
@@ -1,0 +1,47 @@
+
+export type WordsListResponseData = Word[];
+export interface WordsListRequestParams {
+    ayah_uuid?: string;
+    limit?: number;
+    offset?: number;
+    ordering?: string;
+    search?: string;
+}
+export interface WordsCreateRequestData {
+    ayah_uuid: string;
+    text: string;
+}
+export interface WordsCreateResponseData {
+    text: string;
+    uuid: string;
+}
+export interface WordsCreateRequestParams {
+    ayah_uuid?: string;
+}
+export interface WordsRetrieveResponseData {
+    text: string;
+    uuid: string;
+}
+export interface WordsUpdateRequestData {
+    ayah_uuid: string;
+    text: string;
+}
+export interface WordsUpdateResponseData {
+    text: string;
+    uuid: string;
+}
+export interface WordsPartialupdateRequestData {
+    ayah_uuid?: string;
+    text?: string;
+}
+export interface WordsPartialupdateResponseData {
+    text: string;
+    uuid: string;
+}
+
+
+export interface Word {
+    uuid: string;
+    text: string;
+    ayah_uuid: string;
+}


### PR DESCRIPTION
Filter `readOnly` and `writeOnly` fields in generated TypeScript types to align with OpenAPI specifications.

The previous implementation included all properties from an OpenAPI schema in generated TypeScript types, regardless of their `readOnly` or `writeOnly` status. This led to `readOnly` fields appearing in request types and `writeOnly` fields appearing in response types, which is incorrect according to OpenAPI's intended semantics. This PR introduces a `context` parameter to the property extraction logic, allowing for proper filtering of these fields based on whether a request or response type is being generated.

---
<a href="https://cursor.com/background-agent?bcId=bc-67b9d724-e9e0-404a-a118-81b017748287">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-67b9d724-e9e0-404a-a118-81b017748287">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

